### PR TITLE
Fixed report command bug and changes default behaviour

### DIFF
--- a/command/report.go
+++ b/command/report.go
@@ -52,7 +52,7 @@ Options:
 
   Commit Limiting:
 
-  -n int=1                   Limit output, 0 is no limits, defaults to 1 when no limiting flags otherwise defaults to 0
+  -n int=1                   Limit output, 0 is no limit, defaults to 0
   -from-date=yyyy-mm-dd      Show commits starting from this date
   -to-date=yyyy-mm-dd        Show commits thru the end of this date
   -author=""                 Show commits which contain author substring
@@ -86,7 +86,7 @@ func (c ReportCmd) Run(args []string) int {
 	cmdFlags.BoolVar(&terminalOff, "terminal-off", false, "")
 	cmdFlags.BoolVar(&appOff, "app-off", false, "")
 	cmdFlags.StringVar(&format, "format", "commits", "")
-	cmdFlags.IntVar(&limit, "n", -1, "")
+	cmdFlags.IntVar(&limit, "n", 0, "")
 	cmdFlags.BoolVar(&fullMessage, "full-message", false, "")
 	cmdFlags.StringVar(&fromDate, "from-date", "", "")
 	cmdFlags.StringVar(&toDate, "to-date", "", "")
@@ -189,12 +189,6 @@ func (c ReportCmd) Run(args []string) int {
 		if err != nil {
 			c.UI.Error(err.Error())
 			return 1
-		}
-
-		// if project format and not set differently, we want all commits for the project
-		if format == "project" && limit == -1 {
-			// limit of 0 symbolises no limit
-			limit = 0
 		}
 
 		limiter, err := scm.NewCommitLimiter(

--- a/command/report.go
+++ b/command/report.go
@@ -52,7 +52,7 @@ Options:
 
   Commit Limiting:
 
-  -n int=1                   Limit output, 0 is no limit, defaults to 0
+  -n int=0                   Limit output, 0 is no limit
   -from-date=yyyy-mm-dd      Show commits starting from this date
   -to-date=yyyy-mm-dd        Show commits thru the end of this date
   -author=""                 Show commits which contain author substring

--- a/command/report.go
+++ b/command/report.go
@@ -86,7 +86,7 @@ func (c ReportCmd) Run(args []string) int {
 	cmdFlags.BoolVar(&terminalOff, "terminal-off", false, "")
 	cmdFlags.BoolVar(&appOff, "app-off", false, "")
 	cmdFlags.StringVar(&format, "format", "commits", "")
-	cmdFlags.IntVar(&limit, "n", 0, "")
+	cmdFlags.IntVar(&limit, "n", -1, "")
 	cmdFlags.BoolVar(&fullMessage, "full-message", false, "")
 	cmdFlags.StringVar(&fromDate, "from-date", "", "")
 	cmdFlags.StringVar(&toDate, "to-date", "", "")
@@ -191,10 +191,10 @@ func (c ReportCmd) Run(args []string) int {
 			return 1
 		}
 
-		// hack, if project format we want all commits for the project
-		if format == "project" && limit == 0 {
-			// set max to absurdly high value for number of possible commits
-			limit = 2147483647
+		// if project format and not set differently, we want all commits for the project
+		if format == "project" && limit == -1 {
+			// limit of 0 symbolises no limit
+			limit = 0
 		}
 
 		limiter, err := scm.NewCommitLimiter(

--- a/scm/git.go
+++ b/scm/git.go
@@ -153,16 +153,6 @@ func NewCommitLimiter(
 
 	hasAuthor := author != ""
 	hasMessage := message != ""
-
-	// If no limit has manually been set, 0 or 1 is chosen depending on other settings
-	if max == -1 {
-		if !(dateRange.IsSet() || hasAuthor || hasMessage) {
-			max = 0
-		} else {
-			max = 1
-		}
-	}
-
 	hasMax := max > 0
 
 	return CommitLimiter{

--- a/scm/git.go
+++ b/scm/git.go
@@ -151,15 +151,19 @@ func NewCommitLimiter(
 		dateRange = util.LastYearRange()
 	}
 
-	hasMax := max > 0
 	hasAuthor := author != ""
 	hasMessage := message != ""
 
-	if !(hasMax || dateRange.IsSet() || hasAuthor || hasMessage) {
-		// if no limits set default to max of one result
-		hasMax = true
-		max = 1
+	// If no limit has manually been set, 0 or 1 is chosen depending on other settings
+	if max == -1 {
+		if !(dateRange.IsSet() || hasAuthor || hasMessage) {
+			max = 0
+		} else {
+			max = 1
+		}
 	}
+
+	hasMax := max > 0
 
 	return CommitLimiter{
 		DateRange:  dateRange,


### PR DESCRIPTION

This pull request consists of two commits. I would recommend looking at those separately.
The first commit fixes a bug related to a setting in gtm. The second commit changes the default behaviour in that setting, so it reverts some of the changes in the first commit.
I think the change makes much sense (and I'll explain my reasoning here) but I did it that way so if you disagree, you could still use the first commit which just fixed the bug.

# Here is a short reasoning of the two commits:

## Fixed that -n=0 previously didn't work 
Previously, the limiter has been automatically set to zero. And in a case where no additional limiting flags have been present, it has been set to one.
That has created the bug that if someone has manually set the limiter to zero, that didn’t work, as there was no difference in setting it to zero and not setting it at all.

So I have changed the standard setting to -1. So now only if it has not explicitly been set to a different value (and remained at -1), it will get set to either zero or one (depending if there’s an additional limiter or not).
So now, if someone explicitly sets it to zero, that won’t change and it will work.

Additionally, if the project summary type is selected, all commits should be shown as well. Previously, there has been selected a high arbitrary number. While it works, it has described as „hack“ itself and is not very nice. Now I could also replace that just to setting it to zero which symbolises no limit (and won’t be changed in NewCommandLimiter anymore).

## Changed default setting to -n=0 
I've changed the default setting of n to zero. So now, unless explicitly stated differently, information for all commits will appear. I went through every single report type and think that this overall makes much more sense:

- Summary: With summary, it makes absolutely no sense to have n=1 as default. The summary just shows the time for each commit and with n=1 it just shows the number of the last commit, opposed to a real report of the time of each commit
- Project: The one type where it already has n=0 as default value
- Commits: The default value, also here I think it makes more sense to use n=0. The gtm report command reminds much of the git log command, which also doesn't just show information for the latest commit but for all existing. In general, if you want a report, that is supposed to be reporting the time spent on all commits. If someone just needs information for the latest one, n=0 shows it for every separated, so including the latest one. I would argue that having a report for all commits definitely is the expected and (in most cases) wanted behaviour.
- Files: n=0 makes more sense here as well. If you want to see on which files you spent how much time, in most cases you would want that for all commits obviously to see the time for each file. If someone just wants it for the latest commit, there is no real difference to the commit setting anyways.
- Timeline-Hours: I would argue in most cases n=0 is the expected behaviour to see when you've programmed how much and have that as a diagram. Just having it for the latest commit can be also interesting in rare occasions, but it doesn't make much sense to me as default behaviour.
- Timeline-Commits: Just using n=1 as default behaviour doesn't make much sense. That doesn't show a diagram but just one yellow bar - for the latest commit. Expected is a diagram of when you've made how many commits -> so n=0

In general, for the report command having a report of all commits and everything you've programmed in that project is the behaviour I think you'd want for most cases - it's also the standard for other programs like git itself with the logging command, so it's the expected behaviour as well. I just explicitly wrote it for the different categories to show that it makes sense in each one.

If you really don't agree with this (then I would find the reasoning for that interesting), you can of course only use the first commit which fixes the bug that you previously couldn't use n=0, but I think it would definitely improve the report command and it's simplicity to use both :)